### PR TITLE
add function to stage modified files 

### DIFF
--- a/pre_commit_hooks/runner.py
+++ b/pre_commit_hooks/runner.py
@@ -12,3 +12,17 @@ def run_sbt_command(task_def, missing_plugin_check_string=None, missing_plugin_e
         print(raw_output)
 
     return sbt_process.returncode
+
+def run_git_add_modified():
+    """Adds stages files if changes are detected."""
+    try:
+        # Check if there are modified files before running git add -u
+        status = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
+
+        if status.stdout.strip():  # If there are modified files
+            print("Staged formatted files.")
+            return subprocess.run(["git", "add", "-u"], check=True)
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+        return e.returncode

--- a/pre_commit_hooks/scalafmt_apply.py
+++ b/pre_commit_hooks/scalafmt_apply.py
@@ -1,4 +1,4 @@
-from pre_commit_hooks.runner import run_sbt_command
+from pre_commit_hooks.runner import run_sbt_command, run_git_add_modified
 from colorama import init as colorama_init, Fore
 
 TASK_SCALAFMT = 'scalafmtAll'
@@ -9,7 +9,10 @@ MISSING_PLUGIN_ERROR_MSG = f'{Fore.RED}ERROR: scalafmt SBT plugin not present! S
 def main(argv=None):
     colorama_init()
 
-    return run_sbt_command(f'; clean ; {TASK_SCALAFMT}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    sbt = run_sbt_command(f'; clean ; {TASK_SCALAFMT}', MISSING_PLUGIN_CHECK_STRING, MISSING_PLUGIN_ERROR_MSG)
+    run_git_add_modified()
+
+    return sbt
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### What
Add function to stage modified file so that scalafmtAll does not appear as failed

### Why
Git pre-commit hook is failing when sbt scalafmtAll modifies files, even though the command itself exits successfully (exit code 0). This likely happens because git expects the working directory to be clean after the pre-commit hook runs. If scalafmtAll modifies any files, git sees uncommitted changes and fails the commit.